### PR TITLE
Allow changelog to branch parameters

### DIFF
--- a/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
+++ b/src/main/java/hudson/plugins/git/ChangelogToBranchOptions.java
@@ -34,6 +34,10 @@ public class ChangelogToBranchOptions extends AbstractDescribableImpl<ChangelogT
         return compareTarget;
     }
 
+    public boolean isLocalTarget() {
+	return compareRemote == null || "".equals(compareRemote);
+    }
+
     @Extension
     public static class DescriptorImpl extends Descriptor<ChangelogToBranchOptions> {
 

--- a/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
+++ b/src/main/java/hudson/plugins/git/extensions/impl/ChangelogToBranch.java
@@ -9,13 +9,14 @@ import hudson.plugins.git.extensions.GitSCMExtensionDescriptor;
 
 /**
  * This extension activates the alternative changelog computation,
- * where the changelog is calculated against a specified branch or tag.
+ * where the changelog is calculated against a specified remote branch or any local reference
+ * (e.g. branch, tag or other revision syntax which supports being prefixed by "^").
  *
  * @author <a href="mailto:dirk.reske@t-systems.com">Dirk Reske (dirk.reske@t-systems.com)</a>
  */
 public class ChangelogToBranch extends GitSCMExtension {
 
-    private ChangelogToBranchOptions options;
+    private final ChangelogToBranchOptions options;
 
     @DataBoundConstructor
     public ChangelogToBranch(ChangelogToBranchOptions options) {
@@ -23,6 +24,15 @@ public class ChangelogToBranch extends GitSCMExtension {
             throw new IllegalArgumentException("options may not be null");
         }
         this.options = options;
+    }
+
+    @Override
+    public boolean requiresWorkspaceForPolling() {
+	// Documentation in help.html (probably copy/pasted) claimed that this extension required
+	// a workspace for polling.  However, in fact it did not prior to work on JENKINS-51633.
+	// Rather than always return true, maintain backward compatability since isLocalTarget() will
+	// be false for all previously valid configurations.
+        return options.isLocalTarget();
     }
 
     public ChangelogToBranchOptions getOptions() {

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareRemote.html
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareRemote.html
@@ -1,3 +1,3 @@
 <div>
-    Name of the repository, such as <tt>origin</tt>, that contains the branch you specify below.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.  Can be blank to use a local target.
+    Name of the repository, such as <tt>origin</tt>, that contains the branch you specify below.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.  Can be blank to use a local reference (e.g. branch, tag or other revision syntax which supports being prefixed by "^"). <string>Note:</strong> Due to uncertainty of determining if local reference is valid for automated tests: if the remote is blank, this setting will be ignored unless you use 'Check out to specific local branch' as well.
 </div>

--- a/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareTarget.html
+++ b/src/main/resources/hudson/plugins/git/ChangelogToBranchOptions/help-compareTarget.html
@@ -1,3 +1,3 @@
 <div>
-    The name of the branch or tag (local or within the named remote repository) to compare against.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.
+    The name of the remote branch or local reference (e.g. branch, tag or other revision syntax which supports being prefixed by "^") to compare against.  Current build parameters and/or environment variables can be used in form: ${PARAM} or $PARAM.
 </div>

--- a/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
+++ b/src/test/java/hudson/plugins/git/ChangelogToBranchOptionsTest.java
@@ -25,6 +25,8 @@ package hudson.plugins.git;
 
 import org.junit.Test;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.hamcrest.Matchers.*;
 
 public class ChangelogToBranchOptionsTest {
@@ -50,10 +52,20 @@ public class ChangelogToBranchOptionsTest {
     }
 
     @Test
-    public void testAlternateConstructor() {
+    public void testisLocaleTarget() {
+        assertFalse(options.isLocalTarget());
+    }
+
+    @Test
+    public void testAlternateConstructors() {
         ChangelogToBranchOptions newOptions = new ChangelogToBranchOptions(options);
         assertThat(newOptions.getCompareRemote(), is(options.getCompareRemote()));
         assertThat(newOptions.getCompareTarget(), is(options.getCompareTarget()));
+        assertFalse(newOptions.isLocalTarget());
         assertThat(newOptions, is(not(options))); // Does not implement equals
+        newOptions = new ChangelogToBranchOptions(null, options.getCompareTarget());
+        assertTrue(newOptions.isLocalTarget());
+        newOptions = new ChangelogToBranchOptions("", options.getCompareTarget());
+        assertTrue(newOptions.isLocalTarget());
     }
 }

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1174,7 +1174,7 @@ public class GitSCMTest extends AbstractGitTestCase {
             ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions(useChangelogToBranch == 1 ? "origin" : useChangelogToBranch == 2 ? "" : null, "master");
             scm.getExtensions().add(new ChangelogToBranch(changelogOptions));
             if ( useChangelogToBranch > 1 && random.nextBoolean() ) {
-		scm.getExtensions().add(new LocalBranch(random.nextBoolean() ? null : "**"));
+		scm.getExtensions().add(new LocalBranch(""));
             }
         }
         useChangelogToBranch = (useChangelogToBranch+1)%4;

--- a/src/test/java/hudson/plugins/git/GitSCMTest.java
+++ b/src/test/java/hudson/plugins/git/GitSCMTest.java
@@ -1173,6 +1173,9 @@ public class GitSCMTest extends AbstractGitTestCase {
             /* Changelog should be no different with this enabled or disabled */
             ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions(useChangelogToBranch == 1 ? "origin" : useChangelogToBranch == 2 ? "" : null, "master");
             scm.getExtensions().add(new ChangelogToBranch(changelogOptions));
+            if ( useChangelogToBranch > 1 && random.nextBoolean() ) {
+		scm.getExtensions().add(new LocalBranch(random.nextBoolean() ? null : "**"));
+            }
         }
         useChangelogToBranch = (useChangelogToBranch+1)%4;
     }
@@ -1886,6 +1889,18 @@ public class GitSCMTest extends AbstractGitTestCase {
     @Test
     public void testPolling_parentHead_DisableRemotePoll() throws Exception {
         baseTestPolling_parentHead(Collections.<GitSCMExtension>singletonList(new DisableRemotePoll()));
+    }
+
+    @Test
+    public void testPolling_parentHead_ChangelogToBranchRemote() throws Exception {
+        ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions( "origin", "master");
+        baseTestPolling_parentHead(Collections.<GitSCMExtension>singletonList(new ChangelogToBranch(changelogOptions)));
+    }
+
+    @Test
+    public void testPolling_parentHead_ChangelogToBranchLocal() throws Exception {
+        ChangelogToBranchOptions changelogOptions = new ChangelogToBranchOptions( null, "master");
+        baseTestPolling_parentHead(Collections.<GitSCMExtension>singletonList(new ChangelogToBranch(changelogOptions)));
     }
 
     @Test


### PR DESCRIPTION
There were failings in automated acceptance tests.  Upon looking at it, I realize that I misread "Force polling using workspace" behavior to mean the same thing as "Checkout to specific local branch", i.e. for the code to work reliably if the "remote" is left blank, we need to be sure that there is a local workspace.
